### PR TITLE
Allow for throwing exceptions via `calling`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,9 @@ All notable changes to this project are documented in this file.
 
 ## Releases
 
-### 0.4.0 - 2019-01-07
+### 0.3.0 - 2019-01-24
 - Allow mocks to not only return base values, but invoke function calls.
   This enables mocked functions to throw exceptions.
-
-### 0.3.0 - 2018-10-04
 - Allow for use of predicates to match function arguments
 
 ### 0.2.0 - 2018-08-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## Releases
 
+### 0.?.0 - 201?-00-00
+- Allow mocks to not only return base values, but invoke function calls.
+  This enables mocked functions to throw exceptions.
+
 ### 0.2.0 - 2018-08-20
 - Added syntax sugar for clojure.test.
 - Deprecated everything in the `mockfn.core` namespace.

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -38,11 +38,11 @@ for different arguments.
     (is (= :result-2 (one-fn :argument-2)))))
 ```
 
-If you would like to call the value instead of returning it, use `mockfn.mock/as-fn`:
+If you would like to call the value instead of returning it, use `mockfn.macros/calling`:
 
 ```clj
 (testing "providing - calling mocked value as a function"
-  (providing [(one-fn) (as-fn #(throw (ex-info "one-fn failed" {:args 'none})))]
+  (providing [(one-fn) (calling #(throw (ex-info "one-fn failed" {:args 'none})))]
     (is (thrown? ExceptionInfo (one-fn)))))
 ```
 

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -38,6 +38,14 @@ for different arguments.
     (is (= :result-2 (one-fn :argument-2)))))
 ```
 
+If you would like to call the value instead of returning it, use `mockfn.mock/as-fn`:
+
+```clj
+(testing "providing - calling mocked value as a function"
+  (providing [(one-fn) (as-fn #(throw (ex-info "one-fn failed" {:args 'none})))]
+    (is (thrown? ExceptionInfo (one-fn)))))
+```
+
 It's also possible to configure multiple mocks, for multiple functions, at
 once.
 

--- a/project.clj
+++ b/project.clj
@@ -3,4 +3,4 @@
   :url "https://github.com/pmatiello/mockfn"
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]])
+  :dependencies [[org.clojure/clojure "1.10.0"]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject mockfn "0.3.0"
+(defproject mockfn "0.4.0"
   :description "A library for mocking Clojure functions."
   :url "https://github.com/pmatiello/mockfn"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject mockfn "0.4.0"
+(defproject mockfn "0.3.0"
   :description "A library for mocking Clojure functions."
   :url "https://github.com/pmatiello/mockfn"
   :license {:name "Eclipse Public License"

--- a/src/mockfn/macros.clj
+++ b/src/mockfn/macros.clj
@@ -18,6 +18,10 @@
           (assoc-in [func :times-expected (into [] args)] (into [] times-expected))))
     {} bindings))
 
+(defn calling
+  "Invoke mocked value as a function instead of returning it"
+  [func] (mock/->Calling func))
+
 (defmacro providing
   "Mocks functions."
   [bindings & body]

--- a/src/mockfn/mock.clj
+++ b/src/mockfn/mock.clj
@@ -2,11 +2,7 @@
   (:require [mockfn.matchers :as matchers]
             [mockfn.parser]))
 
-(defrecord AsFunc [func])
-
-(defn as-fn
-  "Use mocked value as a function instead of returning it."
-  [func] (->AsFunc func))
+(defrecord Calling [func])
 
 (defn- matches-arg?
   [[expected arg]]
@@ -39,7 +35,7 @@
 
 (defn- base-value-or-invoke [func spec args]
   (let [mocked-value (get-value-for func spec args)]
-    (if (instance? AsFunc mocked-value)
+    (if (instance? Calling mocked-value)
       (apply (:func mocked-value) args)
       mocked-value)))
 

--- a/src/mockfn/mock.clj
+++ b/src/mockfn/mock.clj
@@ -1,6 +1,12 @@
 (ns mockfn.mock
   (:require [mockfn.matchers :as matchers]))
 
+(defrecord AsFunc [func])
+
+(defn as-fn
+  "Use mocked value as a function instead of returning it."
+  [func] (->AsFunc func))
+
 (defn- matches-arg?
   [[expected arg]]
   (if (satisfies? matchers/Matcher expected)
@@ -23,16 +29,22 @@
 (defn- unexpected-call [func args]
   (format "Unexpected call to %s with args %s." func args))
 
-(defn- return-value-for
+(defn- get-value-for
   [func spec args]
   (when (-> spec :return-values (for-args args) #{::unexpected-call})
     (throw (ex-info (unexpected-call func args) {})))
   (-> spec :times-called (for-args args) (swap! inc))
   (-> spec :return-values (for-args args)))
 
+(defn- base-value-or-invoke [func spec args]
+  (let [mocked-value (get-value-for func spec args)]
+    (if (instance? AsFunc mocked-value)
+      (apply (:func mocked-value) args)
+      mocked-value)))
+
 (defn mock [func spec]
   (with-meta
-    (fn [& args] (return-value-for func spec (into [] args)))
+    (fn [& args] (base-value-or-invoke func spec (into [] args)))
     spec))
 
 (defn- doesnt-match [function args matcher times-called]

--- a/test/mockfn/examples/basic_usage.clj
+++ b/test/mockfn/examples/basic_usage.clj
@@ -1,6 +1,7 @@
 (ns mockfn.examples.basic-usage
   (:require [clojure.test :refer :all]
             [mockfn.macros :as mfn]
+            [mockfn.mock :as mck]
             [mockfn.matchers :as matchers])
   (:import (clojure.lang ExceptionInfo)))
 
@@ -16,6 +17,12 @@
     (mfn/providing [(one-fn :argument-1) :result-1
                     (one-fn :argument-2) :result-2]
       (is (= :result-1 (one-fn :argument-1)))
+      (is (= :result-2 (one-fn :argument-2)))))
+
+  (testing "providing - cause function to throw exception"
+    (mfn/providing [(one-fn :argument-1) (mck/as-fn #(throw (ex-info "one-fn mocked to fail" {:arg %})))
+                    (one-fn :argument-2) :result-2]
+      (is (thrown? ExceptionInfo (one-fn :argument-1)))
       (is (= :result-2 (one-fn :argument-2)))))
 
   (testing "providing with more than one function"

--- a/test/mockfn/examples/basic_usage.clj
+++ b/test/mockfn/examples/basic_usage.clj
@@ -1,7 +1,6 @@
 (ns mockfn.examples.basic-usage
   (:require [clojure.test :refer :all]
             [mockfn.macros :as mfn]
-            [mockfn.mock :as mck]
             [mockfn.matchers :as matchers])
   (:import (clojure.lang ExceptionInfo)))
 
@@ -20,7 +19,7 @@
       (is (= :result-2 (one-fn :argument-2)))))
 
   (testing "providing - cause function to throw exception"
-    (mfn/providing [(one-fn :argument-1) (mck/as-fn #(throw (ex-info "one-fn mocked to fail" {:arg %})))
+    (mfn/providing [(one-fn :argument-1) (mfn/calling #(throw (ex-info "one-fn mocked to fail" {:arg %})))
                     (one-fn :argument-2) :result-2]
       (is (thrown? ExceptionInfo (one-fn :argument-1)))
       (is (= :result-2 (one-fn :argument-2)))))


### PR DESCRIPTION
In midje you can do 
```clojure
(fact
  (some-fn) => (throws Exception)
  (provided (some-fn) =throws=> (Exception.)))
```
which isn't currently possible in `mockfn`

This PR extends mockfn to allow for this behavior, and more, by distinguishing between mocking with a base value, or mocking with a function that should be called.

```clojure
(testing "providing - cause function to throw exception"
  (mfn/providing [(one-fn :argument-1) (mck/as-fn #(throw (ex-info "one-fn failedl" {:arg %})))
                  (one-fn :argument-2) :result-2]
    (is (thrown? ExceptionInfo (one-fn :argument-1)))
    (is (= :result-2 (one-fn :argument-2)))))
```

NOTE:
I haven't written very many tests because I want to demonstrate the idea before making it ready to merge. Once I get some initial comments I'll finish up the PR.