### PR TITLE
Add calling-original return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented in this file.
 
 ## Releases
 
+### 0.4.0 - UNRELEASED
+- Allow mocks to call the original function implementation.
+
 ### 0.3.0 - 2019-01-25
 - Allow mocks to not only return base values, but invoke function calls.
   This enables mocked functions to throw exceptions.

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -38,14 +38,6 @@ for different arguments.
     (is (= :result-2 (one-fn :argument-2)))))
 ```
 
-If you would like to call the value instead of returning it, use `mockfn.macros/calling`:
-
-```clj
-(testing "providing - calling mocked value as a function"
-  (providing [(one-fn) (calling #(throw (ex-info "one-fn failed" {:args 'none})))]
-    (is (thrown? ExceptionInfo (one-fn)))))
-```
-
 It's also possible to configure multiple mocks, for multiple functions, at
 once.
 
@@ -55,6 +47,28 @@ once.
               (other-fn :argument) :result-2]
     (is (= :result-1 (one-fn :argument)))
     (is (= :result-2 (other-fn :argument))))))
+```
+
+#### `calling`
+
+If you would like to call the value instead of returning it, use `mockfn.macros/calling`:
+
+```clj
+(testing "providing - calling mocked value as a function"
+  (providing [(one-fn) (calling #(throw (ex-info "one-fn failed" {:args 'none})))]
+    (is (thrown? ExceptionInfo (one-fn)))))
+```
+
+#### `unmocked`
+
+When mocking it is sometimes useful to set some mocks to point to their
+original implementation. This can be done by using `mockfn.macros/unmocked`:
+
+```clj
+(testing "providing - using unmocked to default to original function"
+  (providing [(one-fn :argument-1) unmocked
+              (one-fn :argument-2) :result-2]
+    (is (thrown? ExceptionInfo (one-fn)))))
 ```
 
 ### Verifying Interactions
@@ -175,7 +189,9 @@ need to explicitly be wrapped in the `pred` matcher.
 
 ## External Matchers
 
-Using the `pred` matcher, one can call out to external matchers
+Functions placed in the argument position of mocks will be treated as `pred`
+matchers by default. Thus, one can make use of external predicate functions to
+perform matching.
 
 ### matcher-combinators
 

--- a/src/mockfn/macros.clj
+++ b/src/mockfn/macros.clj
@@ -19,8 +19,12 @@
     {} bindings))
 
 (defn calling
-  "Invoke mocked value as a function instead of returning it"
+  "Invoke mocked value as a function instead of returning it."
   [func] (mock/->Calling func))
+
+(def calling-original
+  "Invoke the original implementation of the mocked function."
+  (mock/->CallingOriginal))
 
 (defmacro providing
   "Mocks functions."

--- a/src/mockfn/macros.clj
+++ b/src/mockfn/macros.clj
@@ -22,7 +22,7 @@
   "Invoke mocked value as a function instead of returning it."
   [func] (mock/->Calling func))
 
-(def calling-original
+(def unmocked
   "Invoke the original implementation of the mocked function."
   (mock/->CallingOriginal))
 

--- a/src/mockfn/mock.clj
+++ b/src/mockfn/mock.clj
@@ -2,7 +2,7 @@
   (:require [mockfn.matchers :as matchers]
             [mockfn.parser]))
 
-(defrecord Calling [func])
+(defrecord Calling [function])
 
 (defrecord CallingOriginal [])
 
@@ -35,21 +35,21 @@
   (-> spec :times-called (for-args args) (swap! inc))
   (-> spec :return-values (for-args args)))
 
-(defn- base-value-or-invoke [func spec args]
+(defn- return-value-for-call [func spec args]
   (let [mocked-value (get-value-for func spec args)]
     (cond
       (instance? Calling mocked-value)
-      (apply (:func mocked-value) args)
+      (-> mocked-value :function (apply args))
 
       (instance? CallingOriginal mocked-value)
-      (apply (:function spec) args)
+      (-> spec :function (apply args))
 
       :default
       mocked-value)))
 
 (defn mock [func spec]
   (with-meta
-    (fn [& args] (base-value-or-invoke func spec (into [] args)))
+    (fn [& args] (return-value-for-call func spec (into [] args)))
     spec))
 
 (defn- doesnt-match [function args matcher times-called]

--- a/src/mockfn/mock.clj
+++ b/src/mockfn/mock.clj
@@ -4,6 +4,8 @@
 
 (defrecord Calling [func])
 
+(defrecord CallingOriginal [])
+
 (defn- matches-arg?
   [[expected arg]]
   (if (satisfies? matchers/Matcher expected)
@@ -35,8 +37,14 @@
 
 (defn- base-value-or-invoke [func spec args]
   (let [mocked-value (get-value-for func spec args)]
-    (if (instance? Calling mocked-value)
+    (cond
+      (instance? Calling mocked-value)
       (apply (:func mocked-value) args)
+
+      (instance? CallingOriginal mocked-value)
+      (apply (:function spec) args)
+
+      :default
       mocked-value)))
 
 (defn mock [func spec]

--- a/test/mockfn/examples/basic_usage.clj
+++ b/test/mockfn/examples/basic_usage.clj
@@ -6,6 +6,7 @@
 
 (def one-fn)
 (def other-fn)
+(defn implemented-fn [x] x)
 
 (deftest examples-test
   (testing "providing"
@@ -41,6 +42,10 @@
                     (one-fn (matchers/exactly inc)) :inc-fn]
       (is (= :odd (one-fn 1)))
       (is (= :inc-fn (one-fn inc)))))
+
+  (testing "providing - calling original"
+    (mfn/providing [(implemented-fn :argument-1) mfn/calling-original]
+      (is (= :argument-1 (implemented-fn :argument-1)))))
 
   (testing "verifying"
     (mfn/verifying [(one-fn :argument) :result (matchers/exactly 1)]

--- a/test/mockfn/examples/basic_usage.clj
+++ b/test/mockfn/examples/basic_usage.clj
@@ -43,9 +43,11 @@
       (is (= :odd (one-fn 1)))
       (is (= :inc-fn (one-fn inc)))))
 
-  (testing "providing - calling original"
-    (mfn/providing [(implemented-fn :argument-1) mfn/unmocked]
-      (is (= :argument-1 (implemented-fn :argument-1)))))
+  (testing "providing - unmocked"
+    (mfn/providing [(implemented-fn :argument-1) mfn/unmocked
+                    (implemented-fn :argument-2) :result-2]
+      (is (= :argument-1 (implemented-fn :argument-1)))
+      (is (= :result-2 (implemented-fn :argument-2)))))
 
   (testing "verifying"
     (mfn/verifying [(one-fn :argument) :result (matchers/exactly 1)]

--- a/test/mockfn/examples/basic_usage.clj
+++ b/test/mockfn/examples/basic_usage.clj
@@ -44,7 +44,7 @@
       (is (= :inc-fn (one-fn inc)))))
 
   (testing "providing - calling original"
-    (mfn/providing [(implemented-fn :argument-1) mfn/calling-original]
+    (mfn/providing [(implemented-fn :argument-1) mfn/unmocked]
       (is (= :argument-1 (implemented-fn :argument-1)))))
 
   (testing "verifying"

--- a/test/mockfn/mock_test.clj
+++ b/test/mockfn/mock_test.clj
@@ -75,7 +75,7 @@
       (is (= 1 (-> mock meta (get-in [:times-called [(matchers/pred odd?)]]) deref)))
       (is (= 1 (-> mock meta (get-in [:times-called [(matchers/any)]]) deref))))))
 
-(deftest mock-calling-original
+(deftest mock-unmocked
   (let [definition {:function      (fn [& args] args)
                     :return-values {[]            (mock/->CallingOriginal)
                                     [:arg1]       (mock/->CallingOriginal)

--- a/test/mockfn/mock_test.clj
+++ b/test/mockfn/mock_test.clj
@@ -74,3 +74,22 @@
       (is (= 1 (-> mock meta (get-in [:times-called [(matchers/a Keyword)]]) deref)))
       (is (= 1 (-> mock meta (get-in [:times-called [(matchers/pred odd?)]]) deref)))
       (is (= 1 (-> mock meta (get-in [:times-called [(matchers/any)]]) deref))))))
+
+(deftest mock-calling-original
+  (let [definition {:function      (fn [& args] args)
+                    :return-values {[]            (mock/->CallingOriginal)
+                                    [:arg1]       (mock/->CallingOriginal)
+                                    [:arg1 :arg2] (mock/->CallingOriginal)}
+                    :times-called  {[]            (atom 0)
+                                    [:arg1]       (atom 0)
+                                    [:arg1 :arg2] (atom 0)}}
+        mock       (mock/mock one-fn definition)]
+    (testing "returns to expected calls with configured return values"
+      (is (= nil (mock)))
+      (is (= [:arg1] (mock :arg1)))
+      (is (= [:arg1 :arg2] (mock :arg1 :arg2))))
+
+    (testing "throws exception when called with unexpected arguments"
+      (is (thrown-with-msg?
+            ExceptionInfo #"Unexpected call to Unbound: #'mockfn.mock-test/one-fn with args \[:unexpected\]"
+            (mock :unexpected))))))


### PR DESCRIPTION
The `calling-original` return calls the original implementation of the mocked function instead of returning a stubbed value.