### PR TITLE
verifying returns the return value of the body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented in this file.
 
 ## Releases
 
+### Unreleased
+- `verifying` now returns the return value of the body (like `providing` does)
+
 ### 0.5.0 - 2019-09-04
 - Support for mocking private functions.
 
@@ -23,7 +26,7 @@ All notable changes to this project are documented in this file.
 ### 0.1.0 - 2018-03-18
 - Added function stubs.
 - Added call verification.
-- Added argument matchers. 
+- Added argument matchers.
 
 ## Planned
 

--- a/src/mockfn/macros.cljc
+++ b/src/mockfn/macros.cljc
@@ -22,6 +22,7 @@
   [bindings & body]
   (let [specs# (->> bindings (partition 3) internal.macro/bindings->specification)]
     `(with-redefs ~(internal.macro/specification->redef-bindings specs#)
-       ~@body
-       (doseq [mock# (keys ~specs#)]
-         (mock/verify mock#)))))
+       (let [res# (do ~@body)]
+         (doseq [mock# (keys ~specs#)]
+           (mock/verify mock#))
+         res#))))

--- a/test/mockfn/macros_test.cljc
+++ b/test/mockfn/macros_test.cljc
@@ -8,8 +8,16 @@
 (deftest providing-test
   (testing "mocks functions without arguments"
     (macros/providing
-      [(fixtures/one-fn) :mocked]
-      (is (= :mocked (fixtures/one-fn)))))
+     [(fixtures/one-fn) :mocked]
+     (is (= :mocked (fixtures/one-fn)))))
+
+  (testing "returns return value of body"
+    (is (true? (macros/providing
+                [(fixtures/one-fn) :mocked]
+                (= :mocked (fixtures/one-fn)))))
+    (is (false? (macros/providing
+                [(fixtures/one-fn) :mocked]
+                (= :other (fixtures/one-fn))))))
 
   (testing "mocks functions with arguments"
     (macros/providing
@@ -49,6 +57,14 @@
     (macros/verifying
       [(fixtures/one-fn) :mocked (matchers/exactly 1)]
       (is (= :mocked (fixtures/one-fn)))))
+
+  (testing "returns return value of body"
+    (is (true? (macros/verifying
+                [(fixtures/one-fn) :mocked (matchers/exactly 1)]
+                (= :mocked (fixtures/one-fn)))))
+    (is (false? (macros/verifying
+                [(fixtures/one-fn) :mocked (matchers/exactly 1)]
+                (= :other (fixtures/one-fn))))))
 
   (testing "mocks functions with arguments"
     (macros/verifying


### PR DESCRIPTION
Before this, 'providing' returned the return value of the body, but 'verifying' did not. This aligns them, and makes it easier to use them outside the context of clojure.test.